### PR TITLE
Add asdf plugin.

### DIFF
--- a/packages/asdf
+++ b/packages/asdf
@@ -1,0 +1,4 @@
+type = plugin
+repository = https://github.com/doughsay/omf-asdf
+maintainer = Chris Dosé <chris.dose@gmail.com>
+description = Access to asdf through oh-my-fish plugin rather than manual install


### PR DESCRIPTION
Simple plugin to access asdf without manually messing with config.fish and copying completions file.  See [README](https://github.com/doughsay/omf-asdf) for some more details.