### PR TITLE
Add graystatus theme

### DIFF
--- a/packages/graystatus
+++ b/packages/graystatus
@@ -1,0 +1,4 @@
+type = theme
+repository = https://github.com/usami-k/graystatus
+maintainer = USAMI Kosuke <usami.kosuke@gmail.com>
+description = modest prompt theme for fish shell


### PR DESCRIPTION
I made a modest prompt theme for fish shell : https://github.com/usami-k/graystatus
I would like to add it to the public repository of oh-my-fish.
