### PR TITLE
Add gls plugin

### DIFF
--- a/packages/gls
+++ b/packages/gls
@@ -1,0 +1,4 @@
+type = plugin
+repository = https://github.com/usami-k/gls
+maintainer = USAMI Kosuke <usami.kosuke@gmail.com>
+description = GNU ls support on macOS


### PR DESCRIPTION
I made a fish shell plugin for GNU ls support on macOS : https://github.com/usami-k/gls
I would like to add it to the public repository of oh-my-fish.