### PR TITLE
Fixed fish_logo plugin reference to the original repo

### DIFF
--- a/packages/fish_logo
+++ b/packages/fish_logo
@@ -1,3 +1,4 @@
 type = plugin
-repository = https://github.com/HenrikWL/plugin-fish_logo
-description = A fish_logo function for the fish shell, creating the ASCII art fish
+repository = https://github.com/laughedelic/fish_logo
+maintainer = Alexey Alekhin <laughedelic@gmail.com>
+description = Fish-shell colorful ASCII-art logo


### PR DESCRIPTION
Previously mentioned [HenrikWL/plugin-fish_logo](https://github.com/HenrikWL/plugin-fish_logo) repo was a "port" of my plugin for omf. Since the original plugin is compatible with omf, I'm replacing the clone plugin with the original one.