### PR TITLE
Update keychain package

### DIFF
--- a/packages/keychain
+++ b/packages/keychain
@@ -1,2 +1,4 @@
 type = plugin
-repository = https://github.com/pkg-gretel/pkg-keychain
+repository = https://github.com/jitakirin/pkg-keychain.git
+maintainer = jitakirin <jitakirin@gmail.com>
+description = Keychain helps you manage SSH and GPG keys


### PR DESCRIPTION
- improves compatibility with OMF
- optimises loading
- allows customising options
- fixes case where SHELL var is not set

Compared to the original keychain package this one uses different default options - just `--quiet`.  All the other options used by the plugin before are in fact a matter of preference and IMHO shouldn't be default, e.g. `--confhost` which reads SSH config to get a list of used keys, but produces a warning if SSH config file isn't found, `--timeout` which clears keys from agent after specified time, can be a bit annoying, and GPG isn't used on every system.

Given that customising options is now as easy as `set -U keychain_init_args --quiet --confhost` and that keychain's options really depend on use-case, I think it makes sense to be less opinionated.
