### PR TITLE
Pipenv plugin: Enables pipenv shell activation

### DIFF
--- a/packages/pipenv
+++ b/packages/pipenv
@@ -1,0 +1,5 @@
+type = plugin
+repository = https://github.com/pantuza/omf-pipenv/
+description = Completion plugin for Pipenv (Python Development Workflow for
+Humans)
+maintainer = Gustavo Pantuza <gustavopantuza@gmail.com>


### PR DESCRIPTION
The [pipenv](https://github.com/kennethreitz/pipenv/) author wrote a plugin for automatically activate pipenv shell. I just ported his code to use with Oh My Fish.

> PS: PR title and description were edited to best fit the plugin purpose. 