### PR TITLE
Add: enlarge_your_git_alias plugin

### DIFF
--- a/packages/enlarge_your_git_alias
+++ b/packages/enlarge_your_git_alias
@@ -1,0 +1,3 @@
+type = plugin
+repository = https://gitlab.com/pinage404/omf_pkg_enlarge_your_git_alias
+description = Plugin that copies each git-alias as abbreviations in Fish Shell


### PR DESCRIPTION
This plugin copies each [`git-alias`](https://git-scm.com/book/tr/v2/Git-Basics-Git-Aliases) as abbreviations in [Fish Shell](https://fishshell.com)

[Git Extras](https://github.com/tj/git-extras/blob/master/Installation.md) must be installed