### PR TITLE
Add bongnoster theme and last-working-dir package

### DIFF
--- a/packages/bongnoster
+++ b/packages/bongnoster
@@ -1,3 +1,4 @@
-
 type = theme
 repository = https://github.com/kfkonrad/bongnoster-fish-theme
+description = A more slender adaption of the agnoster theme that displays the current user, path and VCS information
+maintainer = Kevin F. Konrad <info@kevinkonrad.de>

--- a/packages/bongnoster
+++ b/packages/bongnoster
@@ -1,0 +1,3 @@
+
+type = theme
+repository = https://github.com/kfkonrad/bongnoster-fish-theme

--- a/packages/last-working-dir
+++ b/packages/last-working-dir
@@ -1,4 +1,4 @@
-
 type = plugin
 repository = https://github.com/kfkonrad/last-working-dir-fish-pkg
 description = Always open new fish shells in your last working directory (i.e. the last directory you cd'd into)
+maintainer = Kevin F. Konrad <info@kevinkonrad.de>

--- a/packages/last-working-dir
+++ b/packages/last-working-dir
@@ -1,0 +1,4 @@
+
+type = plugin
+repository = https://github.com/kfkonrad/last-working-dir-fish-pkg
+description = Always open new fish shells in your last working directory (i.e. the last directory you cd'd into)


### PR DESCRIPTION
bongnoster is my variety of agnoster that looks more slender imho.

last-working-dir is inspired by the zsh-plugin with the same name. The implementation however uses the --on-variable hook and a universal variable instead of an explicit cache file.