### PR TITLE
add neolambda theme to oh-my-fish packages repo

### DIFF
--- a/packages/neolambda
+++ b/packages/neolambda
@@ -1,0 +1,4 @@
+type = theme
+repository = https://github.com/ipatch/theme-neolambda
+maintainer = Chris Jones <chris.r.jones.1983@gmail.com>
+description = An updated for of the lambda theme


### PR DESCRIPTION
Add theme **neolambda** based on the lambda theme.  This theme provides an updated fork of the lambda theme.