### PR TITLE
Update pyenv plugin

### DIFF
--- a/packages/pyenv
+++ b/packages/pyenv
@@ -1,3 +1,4 @@
 type = plugin
-repository = https://github.com/oh-my-fish/plugin-pyenv
-description = Simple Python Version Management integration.
+repository = https://github.com/rominf/omf-plugin-pyenv
+maintainer = Roman Inflianskas <infroma@gmail.com>
+description = Pyenv support plugin for fish-shell


### PR DESCRIPTION
Difference between old and new plugins:
Old plugin doesn't call `status --is-interactive; and . (pyenv init -|psub)`. That means completions are not loaded and PYENV_SHELL is not set. New plugin doesn't call this command either, but it has completions generation script bundled, so completions are generated when `pyenv` is called. It also sets `PYENV_SHELL` on init.