### PR TITLE
Update fzf plugin

### DIFF
--- a/packages/fzf
+++ b/packages/fzf
@@ -1,2 +1,4 @@
 type = plugin
-repository = https://github.com/gretel/pkg-fzf
+repository = https://github.com/jethrokuan/fzf
+maintainer = Jethro Kuan <hi@jethrokuan.com>
+description = Ef-fish-ient fish keybindings for fzf


### PR DESCRIPTION
Differences between old and new plugins:
1. New plugin provides shortcuts.
2. New plugin provides commands for opening file/dir using default editor and `xdg-open` or `open` command.
3. New plugin has better documentation.
4. New plugin is updated frequently.