### PR TITLE
Add feedback

### DIFF
--- a/packages/feedback
+++ b/packages/feedback
@@ -1,0 +1,4 @@
+type = plugin
+repository = https://gitlab.com/lusiadas/feedback
+maintainer = hThoreau
+description = Formatting to display feedback messages, usually in the context of a fish plugin.


### PR DESCRIPTION
A plugin for formatting feedback messages. Usually in the context of a fish plugin. As such, It's a dependency for most of my plugins, including `nav`, `publish` and `peco_utils`