### PR TITLE
add: z.lua - A new cd command that helps you navigate faster by learning your habits

### DIFF
--- a/packages/zlua
+++ b/packages/zlua
@@ -1,0 +1,4 @@
+type = plugin
+repository = https://github.com/skywind3000/z.lua
+description = A new cd command that helps you navigate faster by learning your habits
+maintainer = skywind <skywind3000@163.com>


### PR DESCRIPTION
Features of [z.lua](https://github.com/skywind3000/z.lua):

- **10x** times faster than **fasd** and **autojump**, **3x** times faster than **z.sh**.
- Available for **posix shells**: bash, zsh, dash, sh, ash, busybox and etc.
- Available for Fish Shell, Power Shell and Windows cmd.
- Enhanced matching mode takes you to where ever you want precisely.
- Allow updating database only if `$PWD` changed with "$_ZL_ADD_ONCE" set to 1.
- Interactive selection enables you to choose where to go before cd.
- Interactive selection with FZF (optional).
- Quickly go back to a parent directory instead of typing "cd ../../..".

People using [z.lua](https://github.com/skywind3000/z.lua) said:

- "I like this in principal. I’m pretty damn predictable at the command line and far too lazy to make shortcuts"
- "It feels far more intuitive and it's so incredibly convenient to be able to jump between folders I'm working in without having to traverse an entire tree. The shell used to feel so constraining for me, but tools like this are making me enjoy it so much more. "
- "I can finally have autojump-like functionality on my Raspberry Pi 1 without waiting 30 seconds every time I open a new shell. Thanks z.lua devs."
- "Anyway, z.lua is a promising project. If you only need directory jumping, it may be the best choice."