### PR TITLE
Add apt-aliases plugin

### DIFF
--- a/packages/apt-aliases
+++ b/packages/apt-aliases
@@ -1,0 +1,4 @@
+type = plugin
+repository = https://github.com/Gazorby/apt-aliases
+maintainer = Matthieu <mmacnab22@gmail.com>
+description = Port of oh-my-zsh ubuntu plugin for fish shell


### PR DESCRIPTION
It's a port of the [ubuntu oh-my-zsh plugin](https://github.com/robbyrussell/oh-my-zsh/tree/master/plugins/ubuntu) for fish shell