### PR TITLE
Add git-refresh plugin

### DIFF
--- a/packages/git-refresh
+++ b/packages/git-refresh
@@ -1,0 +1,4 @@
+type: plugin
+repository: https://github.com/avimehenwal/git-refresh.git
+maintainer: Avi Mehenwal <avi@campus.uni-paderborn.de>
+description: git pull automatically wherever you cd inside a git repository


### PR DESCRIPTION
# Plugin Intro

**git-refresh** automates the workflow of updating git repositories as soon
as we cd to them.

Hail Automation! :) Hope it saves you some time and hopefully some frustration.

Project aim is that you never see the following nasty git error warning ever again.

The project aim is that you never see the following git error warning 

```
To https://github.com/USERNAME/REPOSITORY.git
  ! [rejected]        master -> master (non-fast-forward)
error: failed to push some refs to 'https://github.com/USERNAME/REPOSITORY.git'
To prevent you from losing history, non-fast-forward updates were rejected
Merge the remote changes (e.g. 'git pull') before pushing again.  See the
'Note about fast-forwards' section of 'git push --help' for details.
```
 ## Demo

![git-refresh](https://user-images.githubusercontent.com/3624059/59984104-e10a8f00-9626-11e9-9d0e-ec118ab153be.png)

 