### PR TITLE
Update artisan

### DIFF
--- a/packages/artisan
+++ b/packages/artisan
@@ -1,2 +1,4 @@
 type = plugin
-repository = https://github.com/thecotne/omf-plugin-artisan
+repository = https://github.com/james2doyle/omf-plugin-artisan
+maintainer = james2doyle
+description = Laravel artisan completions


### PR DESCRIPTION
The original plugin (https://github.com/thecotne/omf-plugin-artisan) has been archived. Also, the original was actually broken on the current version of fish shell. I forked the original and brought it back to life and added some flag completions