### PR TITLE
Add remove_host plugin

### DIFF
--- a/packages/remove_host
+++ b/packages/remove_host
@@ -1,0 +1,3 @@
+type = plugin
+repository = https://github.com/johanmeiring/fish-remove_host
+description = Adds `remove_host` function to remove host keys from specific lines in known_hosts file.


### PR DESCRIPTION
The PR adds a plugin that adds a `remove_host` function, convenient for removing host keys from specific lines numbers in `~/.ssh/known_hosts`.