### PR TITLE
Add uid-gid plugin

### DIFF
--- a/packages/uid-gid
+++ b/packages/uid-gid
@@ -1,0 +1,3 @@
+type = plugin
+repository = https://github.com/maurocchi/omf-plugin-uid-gid
+description = Expose the user and group IDs as environment variables (UID and GID)


### PR DESCRIPTION
This is a simple plugin to expose the classic bash variables `$UID` and `$GID` as global env vars.
It is sometimes useful with some tools (i.e. Docker). 