### PR TITLE
Added: fnm plugin listing

### DIFF
--- a/packages/fnm
+++ b/packages/fnm
@@ -1,0 +1,4 @@
+type = plugin
+repository = https://github.com/james2doyle/omf-plugin-fnm
+maintainer = james2doyle
+description = Completion support for Schniz/fnm


### PR DESCRIPTION
[fnm](https://github.com/Schniz/fnm) is a "native" and fast replacement for nvm (node version manager) that works well with fish shell