### PR TITLE
Add ghcup plugin

### DIFF
--- a/packages/ghcup
+++ b/packages/ghcup
@@ -1,0 +1,3 @@
+type = plugin
+repository = https://github.com/develop7/omf-ghcup
+maintainer = Andrei Dziahel <develop7@develop7.info>


### PR DESCRIPTION
Introduces an [ghcup](https://www.haskell.org/ghcup/) (a Haskell toolchain manager) integration plugin.