### PR TITLE
Add enhancd plugin

### DIFF
--- a/packages/enhancd
+++ b/packages/enhancd
@@ -1,0 +1,4 @@
+type = plugin
+repository = https://github.com/b4b4r07/enhancd
+maintainer = gazorby <gazorby@pm.me>
+description = A next-generation cd command with your interactive filter


### PR DESCRIPTION
> The new cd command called "enhancd" enhanced the flexibility and usability for a user. enhancd will memorize all directories visited by a user and use it for the pathname resolution. If the log of enhancd have more than one directory path with the same name, enhancd will pass the candidate directories list to the filter within the ENHANCD_FILTER environment variable in order to narrow it down to one directory

I'm not the author of this plugin (it's @b4b4r07), i just ported it to fish :heart: :fish: 