### PR TITLE
Add base16-fish-shell & docker-compose aliases plugin

### DIFF
--- a/packages/base16-fish-shell
+++ b/packages/base16-fish-shell
@@ -1,0 +1,4 @@
+type = plugin
+repository = https://github.com/FabioAntunes/base16-fish-shell
+maintainer = Fabio Antunes <fabioantuness@gmail.com>
+description = Base16 themes for Fish Shell

--- a/packages/docker-compose
+++ b/packages/docker-compose
@@ -1,0 +1,4 @@
+type = plugin
+repository = https://github.com/demartini/plugin-docker-compose
+maintainer = Iolar Demartini Junior <iolardemartini@gmail.com>
+description = Docker Compose aliases plugin for fish shell.


### PR DESCRIPTION

### base16-fish-shell
A pure Fish Shell solution to change your shell's default ANSI colours but most importantly, colours 17 to 21 of your shell's 256 colorspace (if supported by your terminal).

This script makes it possible to honour the original bright colours of your shell (e.g. bright green is still green and so on) while providing additional base16 colours to applications such as Vim.

### docker-compose

A Docker Compose aliases plugin for Oh My Fish based loosely on the Oh My Zsh Docker Compose Plugin.