### PR TITLE
Added MakeMeFish

### DIFF
--- a/packages/makeme
+++ b/packages/makeme
@@ -1,0 +1,4 @@
+type = plugin
+repository = https://github.com/OakNinja/MakeMeFish
+maintainer = OakNinja
+description = Easing the usage of Makefiles with the power of fzf


### PR DESCRIPTION
Added MakeMe / MakeMeFish.

MakeMeFish is a plugin that allows you to easily navigate and preview make targets, using fzf.

The features of MakeMeFish is carefully thought out to do what the user expects it to, regardless of if there is 5, 10 or 100 targets. MakeMeFish lists targets in an expected order where true phony targets get listed first, while file targets and generated targets get listed below. 

The preview allows you to see what the target will actually execute. Interactive mode allows you to run the same target or adjacent targets without leaving MakeMeFish.

Run MakeMeFish with the command `mm` and print the options by running `mm -h` or `mm --help`