### PR TITLE
Add fish-jabba plugin

### DIFF
--- a/packages/jabba
+++ b/packages/jabba
@@ -1,0 +1,4 @@
+type = plugin
+repository = https://github.com/2m/fish-jabba
+maintainer = 2m
+description = Jabba integration with autocomplete features


### PR DESCRIPTION
This is a fish plugin for jabba.  Together with packaging the original
shell integration code required for jabba to work correctly, this
plugin also includes autocompletion support for a few commands.