### PR TITLE
add nix_freeze

### DIFF
--- a/packages/nix_freeze
+++ b/packages/nix_freeze
@@ -1,0 +1,3 @@
+type = plugin
+repository = https://gitlab.com/pinage404/omf_pkg_nix_freeze
+description = Help to freeze nix's channel for nix-shell


### PR DESCRIPTION
add [`nix_freeze`](https://gitlab.com/pinage404/omf_pkg_nix_freeze) a package that help to freeze [`nix`][nix]'s channel for [`nix-shell`][nix-shell]

It works great with [`direnv`][direnv] and [`nixify`][nixify]

[nix]:               https://nixos.org/
[nix-shell]:         https://nixos.wiki/wiki/Development_environment_with_nix-shell

[direnv]:            https://direnv.net/
[nixify]:            https://github.com/direnv/direnv/wiki/Nix#shell-function-to-quickly-setup-nix--direnv-in-a-new-project
