### PR TITLE
Add update-date plugin

### DIFF
--- a/packages/update-date
+++ b/packages/update-date
@@ -1,0 +1,4 @@
+type = plugin
+repository = https://github.com/threeal/omf-plugin-update-date
+maintainer = Alfi Maulana <alfi.maulana.f@gmail.com>
+description = Update system date using HTTP response header.


### PR DESCRIPTION
This is a simple plugin that provides a helper function to update a system date using date info in an HTTP response header.