### PR TITLE
Add pond plugin

### DIFF
--- a/packages/pond
+++ b/packages/pond
@@ -1,0 +1,4 @@
+type = plugin
+repository = https://github.com/marcransome/pond
+maintainer = Marc Ransome <marc.ransome@fidgetbox.co.uk>
+description = A shell environment manager for the fish shell


### PR DESCRIPTION
Add plugin package definition for [pond](http://github.com/marcransome/pond), a shell environment manager for `fish`.