### PR TITLE
Adds ssh-agent plugin

### DIFF
--- a/packages/ssh-agent
+++ b/packages/ssh-agent
@@ -1,0 +1,4 @@
+type = plugin
+repository = https://github.com/bytefluxio/plugin-ssh-agent
+maintainer = Robert Westman <robert@byteflux.io>
+description = Start and share ssh-agent between multiple shells


### PR DESCRIPTION
Automatically starts an ssh-agent, when you open your shell.

The ssh-agent is kept alive.

If ssh-agent can't be connected to, all running ssh-agents, that your shell sees (checked via `ps -a`) are shut down and a new one is started.

Since all shells share the ssh-agent, you only have to enter your password once