### PR TITLE
Update solarfish repository link and maintainer

### DIFF
--- a/packages/solarfish
+++ b/packages/solarfish
@@ -1,4 +1,4 @@
 type = theme
-repository = https://github.com/MrSiliconGuy/theme-solarfish
-maintainer = MrSiliconGuy bcavocado25@gmail.com
+repository = https://github.com/thesilican/theme-solarfish
+maintainer = thesilican <bryanchen74@gmail.com>
 description = A simple, git-aware, two-line fish theme


### PR DESCRIPTION
Update the repository link and maintainer of solarfish theme, from `MrSiliconGuy` to `thesilican`

Username verification: See that https://github.com/MrSiliconGuy/theme-solarfish redirects to https://github.com/thesilican/theme-solarfish