### PR TITLE
Clean up packages

### DIFF
--- a/packages/ansible
+++ b/packages/ansible
@@ -1,2 +1,2 @@
 type = plugin
-repository = https://github.com/pkg-gretel/pkg-ansible
+repository = https://github.com/fishgretel/pkg-ansible

--- a/packages/artisan
+++ b/packages/artisan
@@ -1,4 +1,0 @@
-type = plugin
-repository = https://github.com/james2doyle/omf-plugin-artisan
-maintainer = james2doyle
-description = Laravel artisan completions

--- a/packages/ays
+++ b/packages/ays
@@ -1,2 +1,2 @@
 type = theme
-repository = https://github.com/aollio/ays-fish-theme
+repository = https://github.com/yeseni-today/ays-fish-theme

--- a/packages/barracuda
+++ b/packages/barracuda
@@ -1,4 +1,0 @@
-type = theme
-repository = https://github.com/meverss/barracuda
-maintainer = Marvin Eversley Silva <meverss@outlook.com>
-description = A fork of budspencer theme.

--- a/packages/bongnoster
+++ b/packages/bongnoster
@@ -1,4 +1,0 @@
-type = theme
-repository = https://github.com/kfkonrad/bongnoster-fish-theme
-description = A more slender adaption of the agnoster theme that displays the current user, path and VCS information
-maintainer = Kevin F. Konrad <info@kevinkonrad.de>

--- a/packages/homestead
+++ b/packages/homestead
@@ -1,4 +1,0 @@
-type = plugin
-repository = https://github.com/dwhoban/homestead
-maintainer = Dan Hoban <dan@hoban.digital>
-description = A plugin to access Laravel Homestead globally.

--- a/packages/keychain
+++ b/packages/keychain
@@ -1,4 +1,0 @@
-type = plugin
-repository = https://github.com/jitakirin/pkg-keychain.git
-maintainer = jitakirin <jitakirin@gmail.com>
-description = Keychain helps you manage SSH and GPG keys

--- a/packages/mish
+++ b/packages/mish
@@ -1,4 +1,4 @@
 type = theme
-repository = https://github.com/M4rk9696/theme-mish.git
+repository = https://github.com/Mark1626/theme-mish
 maintainer = M4rk9696 <nimalan.m@protonmail.com>
 description = A minimal fish theme with just the essentials

--- a/packages/node
+++ b/packages/node
@@ -1,3 +1,0 @@
-type = plugin
-repository = https://github.com/oh-my-fish/plugin-node
-description = Adds npm and ./node_modules/.bin to the path

--- a/packages/open_github
+++ b/packages/open_github
@@ -1,4 +1,0 @@
-type = plugin
-repository = https://github.com/patrickf3139/open_github
-maintainer = patrickf3139
-description = Jump to the GitHub PR page or tree view for the current branch

--- a/packages/pastfish
+++ b/packages/pastfish
@@ -1,2 +1,2 @@
 type = theme
-repository = https://github.com/chgu82837/theme-PastFish
+repository = https://github.com/pastleo/theme-PastFish

--- a/packages/pcd
+++ b/packages/pcd
@@ -1,5 +1,5 @@
 type = plugin
-repository = https://github.com/AniketB669/plugin-pcd.git
+repository = https://github.com/heraldofsolace/plugin-pcd
 maintainer = Aniket Bhattacharyea <aniketmail669@gmail.com>
 description = Automatically run a script when cd'ing in or out of a directory
 

--- a/packages/pure
+++ b/packages/pure
@@ -1,2 +1,2 @@
 type = theme
-repository = https://github.com/rafaelrinaldi/theme-pure
+repository = https://github.com/pure-fish/pure

--- a/packages/random
+++ b/packages/random
@@ -1,2 +1,2 @@
 type = theme
-repository = https://github.com/tycho01/theme-random
+repository = https://github.com/KiaraGrouwstra/theme-random

--- a/packages/redfish
+++ b/packages/redfish
@@ -1,3 +1,0 @@
-type = theme
-repository = https://github.com/redxtech/redfish
-description = A minimalistic theme with git information, status codes, and ssh information.

--- a/packages/shellder
+++ b/packages/shellder
@@ -1,3 +1,0 @@
-type = theme
-repository = https://github.com/simnalamburt/shellder
-description = :shell: Featured zsh/fish shell theme

--- a/packages/solarfish
+++ b/packages/solarfish
@@ -1,4 +1,4 @@
 type = theme
-repository = https://github.com/MrSiliconGuy/theme-solarfish
+repository = https://github.com/thesilican/theme-solarfish
 maintainer = MrSiliconGuy bcavocado25@gmail.com
 description = A simple, git-aware, two-line fish theme

--- a/packages/spacefish
+++ b/packages/spacefish
@@ -1,4 +1,0 @@
-type = theme
-repository = https://github.com/matchai/spacefish
-maintainer = Matan Kushner <hello@matchai.me>
-description = 🚀🐟 A fish shell prompt for astronauts

--- a/packages/termux
+++ b/packages/termux
@@ -1,3 +1,0 @@
-type = plugin
-repository = https://github.com/sagebind/plugin-termux
-description = Make Termux less broken

--- a/packages/uid-gid
+++ b/packages/uid-gid
@@ -1,3 +1,3 @@
 type = plugin
-repository = https://github.com/maurocchi/omf-plugin-uid-gid
+repository = https://github.com/enerdgumen/omf-plugin-uid-gid
 description = Expose the user and group IDs as environment variables (UID and GID)

--- a/packages/yadd
+++ b/packages/yadd
@@ -1,4 +1,0 @@
-type = plugin
-repository = https://github.com/redxtech/yadd.git
-maintainer = Gabe Dunn <gabe.dunn@shaw.ca>
-description = A yarn/npm plugin for Oh My Fish.

--- a/packages/zeit
+++ b/packages/zeit
@@ -1,4 +1,4 @@
 type = theme
-repository = https://github.com/mcansh/zeit-fish-theme
+repository = https://github.com/mcansh/vercel-fish-theme
 maintainer = Logan McAnsh logan@mcan.sh
 description = a port of https://github.com/zeit/zeit.zsh-theme


### PR DESCRIPTION
This:

- Removes archived packages because they are likely to be out of date, broken, of no interest to anyone
- Removes packages without an issue tracker, because they leave users no way to report bugs (except for oh-my-fish packages, because they can report to oh-my-fish itself)
- Updates the URLs on moved packages

Only for packages on github because I wrote a small script that crawls the API.

Obsoletes #150, 