### PR TITLE
Update solarfish maintainer

### DIFF
--- a/packages/solarfish
+++ b/packages/solarfish
@@ -1,4 +1,4 @@
 type = theme
 repository = https://github.com/thesilican/theme-solarfish
-maintainer = MrSiliconGuy bcavocado25@gmail.com
+maintainer = Bryan Chen <bryanchen74@gmail.com>
 description = A simple, git-aware, two-line fish theme


### PR DESCRIPTION
Updated version of #150

Thanks to #151, the repo link for solarfish is correct. However, the maintainer and email are still out-of-date.

This PR correctly follows the `maintainer = YOUR-NAME <YOUR-EMAIL>` format as specified in README.md