### PR TITLE
default-git theme derived from default theme

### DIFF
--- a/packages/default-git
+++ b/packages/default-git
@@ -1,0 +1,5 @@
+type = plugin
+repository = https://github.com/kirankotari/default-git/
+maintainer = kirankotari
+description = A feature-rich theme derived from default, a new style to git.
+


### PR DESCRIPTION
In this theme I have split the `git branch` and `current path` to separate lines. Which make a beautiful look and feel. 