### PR TITLE
Add poetry_use_asdf plugin

### DIFF
--- a/packages/poetry_use_asdf
+++ b/packages/poetry_use_asdf
@@ -1,0 +1,5 @@
+type = plugin
+repository = https://github.com/RCristiano/poetry_use_asdf
+maintainer = Rodrigo Cristiano <rcristianofv@hotmail.com>
+description = Allows poetry to use python versions of asdf
+branch = main


### PR DESCRIPTION
I made this plugin because I had a frustration with poetry and asdf together so I thought of this encapsulation so poetry could use the correct install path with the command `poetry env use <python-version>` and `poetry shell`

More details in this [issue](https://github.com/python-poetry/poetry/issues/3890)