### PR TITLE
Add new plugin fish-top

### DIFF
--- a/packages/fish-top
+++ b/packages/fish-top
@@ -1,0 +1,4 @@
+type = plugin
+repository = https://github.com/suizman/fish-top
+maintainer = suizman
+description = Get most used commands in Fish Shell (Top 20)


### PR DESCRIPTION
This new plugin adds the ability to list top used commands for Fish Shell.