### PR TITLE
add plugin worktree

### DIFF
--- a/packages/worktree
+++ b/packages/worktree
@@ -1,0 +1,4 @@
+type = plugin
+repository = https://github.com/oseau/worktree.fish
+maintainer = oseau
+description = A git worktree manager for Fish shell


### PR DESCRIPTION
I've implemented a git worktree manager in fish that I'd like to make available as an omf plugin. Check https://github.com/oseau/worktree.fish for more info.